### PR TITLE
Fixed harmless uncaught exception.

### DIFF
--- a/queue.py
+++ b/queue.py
@@ -194,7 +194,10 @@ class queue(minqlx.Plugin):
             return
         
         elif 529 <= index < 529 + 64:
-            player = self.player(index - 529)
+            try:
+                player = self.player(index - 529)
+            except minqlx.NonexistentPlayerError:
+                return
             
             if self.inafk(player):
                 self.setAFKTag(player)


### PR DESCRIPTION
Recent changes makes Plugin.player() raise an exception instead of returning None when a player doesn't exist. This unhandled exception doesn't really break anything, so it's nothing critical or anything. Might even be for the better, because this means there's a point during connection where a player configstring is being set, but the structures are yet to be initialized, meaning None was being returned and `inafk()` was being called with None. That in itself isn't an issue of course, since it just returns False, but if you ever change the code in the future and don't expect it to be None, it might lead to some weird stuff.
