### PR TITLE
Additions and fixes

### DIFF
--- a/pummel.py
+++ b/pummel.py
@@ -44,7 +44,7 @@ class pummel(minqlx.Plugin):
     
     def cmd_pummel(self, player, msg, channel):
         pummels = self.db.smembers(PLAYER_KEY.format(player.steam_id) + ":pummeled")
-        players = self.teams()["spectator"] + self.teams()["red"] + self.teams()["blue"]
+        players = self.teams()["spectator"] + self.teams()["red"] + self.teams()["blue"] + self.teams()["free"]
         
         msg = ""
         for p in pummels:
@@ -55,5 +55,5 @@ class pummel(minqlx.Plugin):
         if msg == "":
             self.msg("{} has not pummeled anybody on this server.".format(player))
         else:
-            self.msg("^1NAKED ^7DB >> Pummel Stats for {}:".format(player))
+            self.msg("Pummel Stats for {}:".format(player))
             self.msg(msg)

--- a/uneventeams.py
+++ b/uneventeams.py
@@ -187,6 +187,9 @@ class uneventeams(minqlx.Plugin):
         '''
         if new_team == "spectator":
             self._players[player.steam_id].stop()
+        
+        if new_team == "red" or new_team == "blue":
+            self._players[player.steam_id].start()
             
     def handle_player_disconnect(self, player, reason):
         if player.steam_id in self._players.keys():

--- a/uneventeams.py
+++ b/uneventeams.py
@@ -17,7 +17,8 @@
 # he was alive though!
 
 # For now, the plugin warns that teams are uneven on event round_countdown and 
-# slays the player who was in-game the shortest on event round_start.
+# slays or move to spectators the player who was in-game the shortest 
+# on event round_start.
 
 # I wrote a little timer module that can be used to start and stop timers.
 # If a timer was stopped yet not cleared 
@@ -82,6 +83,11 @@ class uneventeams(minqlx.Plugin):
         
         self.initialize()
         
+        # Slay (0) or move to spectators (1) when teams are uneven
+        self.set_cvar_once("qlx_unevenTeamsAction", "0")
+        # Minimum amount of players in red + blue for uneventeams to work
+        self.set_cvar_once("qlx_unevenTeamsMinPlayers", "2")
+        
     def initialize(self):
         '''
             Equip all players with timers on plugin load.
@@ -100,8 +106,13 @@ class uneventeams(minqlx.Plugin):
             Check if teams are uneven and if so, warn the player with the 
             least amount of time played.
         '''
+        min_players = self.get_cvar("qlx_unevenTeamsMinPlayers", int)
+        
         teams = self.teams()
-        if len(teams["red"] + teams["blue"]) % 2 == 0:
+        
+        if len(teams["red"]) == len(teams["blue"]):
+            return
+        if len(teams["red"] + teams["blue"]) < min_players:
             return
         
         if len(teams["red"]) > len(teams["blue"]):
@@ -115,6 +126,9 @@ class uneventeams(minqlx.Plugin):
             Start (or resume) the timers for the players in RED and BLUE.
             Check also if we need to slay someone.
         '''
+        min_players = self.get_cvar("qlx_unevenTeamsMinPlayers", int)
+        action = self.get_cvar("qlx_unevenTeamsAction", int)
+        
         teams = self.teams()
         
         for p in teams["red"]:
@@ -128,20 +142,24 @@ class uneventeams(minqlx.Plugin):
                 self.player(p)
             except:
                 del self._players[p]
-
-        if len(teams["red"] + teams["blue"]) % 2 == 0:
+        
+        if len(teams["red"]) == len(teams["blue"]):
             return
-        if len(teams["red"] + teams["blue"]) == 1:
+        if len(teams["red"] + teams["blue"]) < min_players:
             return
-            
+        
         if len(teams["red"]) > len(teams["blue"]):
             guy = self.player(self.find_lastjoined("red"))
         else:
             guy = self.player(self.find_lastjoined("blue"))
         
-        guy.health = 0
-        self.msg("^1Uneven Teams^7 >> {}^7 was slain.".format(guy.name))
-    
+        if action == 0:
+            guy.health = 0
+            self.msg("^1Uneven Teams^7 >> {}^7 was slain.".format(guy.name))
+        if action == 1:
+            guy.put("spectator")
+            self.msg("^1Uneven Teams^7 >> {}^7 was moved to spectators.".format(guy.name))
+        
     def handle_round_end(self, round_number):
         '''
             The round is over, stop the players' timers.


### PR DESCRIPTION
I did your plugins a bit more universal, for using not with just CA, but FT gamemode as well. Pummel can now be used in non-team based gamemodes. Most of changes are hidden behind the cvars which set to the old behaviour by default. Except for handling the player leave from teams and from server (uneventeams.py). I made the timer to stay for 3 minutes (if someone disconnected because of problems, or went away for a while). Its always making people surprised if someone took the pause for hour or so, then joined, and pushed someone else to spectators, because his timer wasn't reset.

There is only 1 thing, that i didn't: when teams has 4 vs 6 players, the last player from blue team moving to spectators, but not directly to the red team. Too lazy now to think about the clean and simple algo for that.

PS: sorry for my french xD
